### PR TITLE
fix: type error

### DIFF
--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import ThemeSwitcher from "./theme-switcher";
 import Link from "next/link";
 
-const navList = [
+type Item = {
+  name: string;
+  url: string;
+};
+
+const navList: Item[] = [
   {
     name: "產品列表",
     url: "/products",
@@ -13,7 +18,7 @@ const navList = [
   },
 ];
 
-const NavItem = ({name, url}) => (
+const NavItem = ({name, url}: Item) => (
 	<li>
 		<Link className="text-xl" href={url}>
 			{name}
@@ -31,9 +36,9 @@ const Header = () => {
       </div>
       <nav className="flex align-middle">
         <ul className="flex align-middle">
-			{
-				navList.map(item => <NavItem key={item.url} {...item}/>)
-			}
+          {
+            navList.map(item => <NavItem key={item.url} {...item} />)
+          }
         </ul>
       </nav>
       <div>

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 
 interface ProductProps {
     params: {
@@ -12,19 +12,23 @@ interface MetadataProps {
     searchParams: { [key: string]: string | string[] | undefined };
 }
 
+// static slug list
+const productsName: ReadonlyArray<string> = ['mcb1~63a', 'hlc80~125a', 'timer', 'truncking', 'add-on-button'];
+
 export const generateMetadata =  async (
-    { params, searchParams }: MetadataProps,
-    parent?: ResolvingMetadata,
+    { params, searchParams }: MetadataProps
   ): Promise<Metadata>  => {
     const { slug } = params;
-    console.log('generateMetadata', params, searchParams);
-    return {
-      title: slug,
-    };
-  }
+    const metadata: Metadata = {
+        title: slug,
+    }
+        
+    return metadata;
+}
+
 export const dynamicParams = false;
+
 export const generateStaticParams = async () => {
-    const productsName = ['mcb1~63a', 'hlc80~125a', 'timer', 'truncking', 'add-on-button']
     const slugs = productsName.map(slug => ({ slug }));
 
     return slugs


### PR DESCRIPTION
- dynamic metadata type error 
ResolvingMetadata is causing type error
'parent' parameter has been removed."

- add Item type in header component